### PR TITLE
Only use the fhir-validator-wrapper for the time being

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This app is a stand-alone [FHIR](http://fhir.hl7.org/) Resource validator. Using this app, you can upload a FHIR resource and an optional Implementation guide, and have it validated by one of two different validation engines.
+This app is a stand-alone [FHIR](http://fhir.hl7.org/) resource validator. Using this app, you can validate a FHIR resource against an optional FHIR Profile.
 
 ## Running the FHIR Validator App in Docker
 * Build the image, using `docker build . -t fhir_validator_app`

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -30,12 +30,14 @@ module FHIRValidator
 
       resource = get_resource(params)
 
-      @validator = case params[:validator]
-                   when 'hl7'
-                     GrahameValidator.new
-                   when 'inferno'
-                     FHIRModelsValidator.new
-                   end
+      # NOTE: We've disabled the FHIRModelsValidator (and the radio button) for the time being
+      # @validator = case params[:validator]
+      #              when 'hl7'
+      #                GrahameValidator.new
+      #              when 'inferno'
+      #                FHIRModelsValidator.new
+      #              end
+      @validator = GrahameValidator.new
 
       if params[:profile]
         @profile_url = GrahameValidator.profile_url_by_name(params[:profile])

--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <div class="form-group">
+    <%# <div class="form-group">
       <p>Pick a validator engine to use:</p>
       <div class="form-check">
         <input class="form-check-input" type="radio" name="validator" id="hl7" value="hl7" checked />
@@ -51,7 +51,7 @@
           Inferno Validator
         </label>
       </div>
-    </div>
+    </div> %>
 
     <%# <div class="form-group">
       <p>FHIR Version:</p>


### PR DESCRIPTION
This PR comments out the view and app code to choose the validator to be used, and hardcodes the fhir-validator-wrapper as the validator of choice.