### PR TITLE
Webpack optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "react-select": "^3.1.0",
     "react-syntax-highlighter": "^12.2.1",
     "react-syntax-highlighter-virtualized-renderer": "^1.1.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/src/components/Resource.tsx
+++ b/src/components/Resource.tsx
@@ -1,7 +1,12 @@
 import React from "react";
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import { docco as style } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
+import json from 'react-syntax-highlighter/dist/cjs/languages/hljs/json';
+import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml';
+import docco from 'react-syntax-highlighter/dist/cjs/styles/hljs/docco';
+
 import { Issue } from '../models/Issue';
+SyntaxHighlighter.registerLanguage('JSON', json);
+SyntaxHighlighter.registerLanguage('XML', xml);
 
 export interface ResourceProps {
   readonly resource: string;
@@ -26,16 +31,16 @@ export class Resource extends React.Component<ResourceProps, {}> {
     const issueLines = errors.map(e => e.line);
     return(
       <SyntaxHighlighter language={this.props.resourceType} 
-                         style={style}
-                         showLineNumbers={true}
-                         wrapLines={true}
-                         lineProps={(lineNumber: number) => {
-                           return this.highlightProps(lineNumber, issueLines);
-                         }}
-                         lineNumberProps={(lineNumber: number) => {
-                             return this.highlightProps(lineNumber, issueLines);
-                         }}
-                         data-testid="syntax-highlight">
+        style={docco}
+        showLineNumbers={true}
+        wrapLines={true}
+        lineProps={(lineNumber: number) => {
+          return this.highlightProps(lineNumber, issueLines);
+        }}
+        lineNumberProps={(lineNumber: number) => {
+            return this.highlightProps(lineNumber, issueLines);
+        }}
+        data-testid="syntax-highlight">
         { this.decodeResource(this.props.resource) }
       </SyntaxHighlighter>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { Resource } from "./components/Resource";
-import { ProfileSelect } from "./components/ProfileSelect";
 
 import { SelectOption } from './models/SelectOption';
 import { ProfileForm } from "./components/ProfileForm";

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -4,7 +4,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 
 module.exports = merge(common, {
-  mode: "development",
+  mode: "production",
 
   // Enable sourcemaps for debugging webpack's output.
   devtool: "source-map",
@@ -12,4 +12,10 @@ module.exports = merge(common, {
   plugins: [
     new CleanWebpackPlugin()
   ],
+
+  optimization: {
+    removeAvailableModules: true,
+    removeEmptyChunks: true,
+    usedExports: true
+  }
 });


### PR DESCRIPTION
This PR optimizes the bundle size created by Webpack by:
* setting `side_effects` to `false` in `package.json`
* Only importing json/xml languages, because we don't need any others
* Actually set prod mode in webpack.prod.js
w﻿
