### PR TITLE
Fix line number off-by-one error, and re-enable better syntax highlighting

### DIFF
--- a/lib/app/models/validators/hl7_validator.rb
+++ b/lib/app/models/validators/hl7_validator.rb
@@ -58,7 +58,6 @@ module FHIRValidator
         &.extension
         &.find { |e| e.url == 'http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line' }
         &.valueInteger
-        &.next
     end
 
     def self.profile_urls

--- a/src/components/Resource.tsx
+++ b/src/components/Resource.tsx
@@ -5,8 +5,8 @@ import xml from 'react-syntax-highlighter/dist/cjs/languages/hljs/xml';
 import docco from 'react-syntax-highlighter/dist/cjs/styles/hljs/docco';
 
 import { Issue } from '../models/Issue';
-SyntaxHighlighter.registerLanguage('JSON', json);
-SyntaxHighlighter.registerLanguage('XML', xml);
+SyntaxHighlighter.registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('xml', xml);
 
 export interface ResourceProps {
   readonly resource: string;
@@ -28,17 +28,19 @@ export class Resource extends React.Component<ResourceProps, {}> {
     const errors = this.parseIssueArray(this.decodeResource(this.props.errors));
     const warnings = this.parseIssueArray(this.decodeResource(this.props.warnings));
     const information = this.parseIssueArray(this.decodeResource(this.props.information));
-    const issueLines = errors.map(e => e.line);
+    const errorLines = errors.map(e => e.line);
+    const warningLines = warnings.map(w => w.line);
+    const infoLines = information.map(i => i.line);
     return(
       <SyntaxHighlighter language={this.props.resourceType} 
         style={docco}
         showLineNumbers={true}
         wrapLines={true}
         lineProps={(lineNumber: number) => {
-          return this.highlightProps(lineNumber, issueLines);
+          return this.highlightProps(lineNumber, errorLines, warningLines, infoLines);
         }}
         lineNumberProps={(lineNumber: number) => {
-            return this.highlightProps(lineNumber, issueLines);
+          return this.highlightProps(lineNumber, errorLines, warningLines, infoLines);
         }}
         data-testid="syntax-highlight">
         { this.decodeResource(this.props.resource) }
@@ -46,12 +48,18 @@ export class Resource extends React.Component<ResourceProps, {}> {
     );
   }
 
-  highlightProps(lineNumber: number, issueLines: number[]): any {
+  highlightProps(lineNumber: number, errorLines: number[], warningLines: number[], infoLines: number[]): any {
     let style = { 'backgroundColor': '' };
     let className = null;
-    if (issueLines.includes(lineNumber)) {
-      style.backgroundColor = "#ff9e9e";
-      return { style: style, id: `error-${lineNumber}`}
+    if (errorLines.includes(lineNumber)) {
+      style.backgroundColor = "#f8d7da";
+      return { style: style, id: `error-${lineNumber}`};
+    } else if (warningLines.includes(lineNumber)) {
+      style.backgroundColor = "#fff3cd";
+      return { style: style, id: `error-${lineNumber}` };
+    } else if (infoLines.includes(lineNumber)) {
+      style.backgroundColor = "#d1ecf1";
+      return { style: style, id: `error-${lineNumber}` };
     }
     return { style: style };
   }


### PR DESCRIPTION
This PR fixes two issues:
* There was a (purposefully introduced) off-by-one error in the issue line numbers. I swear it used to be necessary, but it no longer appears to be, so it's removed so line numbers are accurate in JS-land.
* The syntax highlighting langauges got registered in ALL CAPS, which kept them from being used. This fixes that.﻿

It also adds line highlighting for warning and informational messages, with corresponding less-threatening colors for each.
