### PR TITLE
FI-844: Pass the informational issues to JS for highlighting/jump-to support

### DIFF
--- a/lib/app/views/validate.erb
+++ b/lib/app/views/validate.erb
@@ -24,7 +24,7 @@
        data-resource-string="<%= @resource_string %>"
        data-issues-errors="<%= Base64.encode64(@results[:errors].to_json) %>"
        data-issues-warnings="<%= Base64.encode64(@results[:warnings].to_json) %>"
-       data-issues-information="<%= Base64.encode64(@results[:warnings].to_json) %>"
+       data-issues-information="<%= Base64.encode64(@results[:information].to_json) %>"
   >
   </div>
 </div>


### PR DESCRIPTION
In order to get the `issue` objects into React-land, we have to serialize them into base64 and dump them into the HTML (Gross, I know, I'm working on a better way to do it, but this was quick-and-dirty). Turns out that method works better when you pass the correct hash key for each issue type.