### PR TITLE
Add readme updates for development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 This app is a stand-alone [FHIR](http://fhir.hl7.org/) resource validator. Using this app, you can validate a FHIR resource against an optional FHIR Profile.
 
 ## Running the FHIR Validator App in development
-### Prerequisites:
-* Install the required version of Ruby: `rvm install` in the `fhir-validator-app` folder
-* Tell RVM to use that version of Ruby: `rvm use`
-  * Note: these two commands make use of the `.ruby-version` file, which specifies the version of Ruby being used by the app. That's why there's no need to specify a Ruby version to either of these commands.
-* Install Bundler: `gem install bundler`
-* Install the Ruby dependencies: `bundle install`
-* Install Node, using your method of choice
-  * I use [Node Version Manager](https://github.com/nvm-sh/nvm), but you can also install Node via homebrew with `brew install node@12` if you're on a Mac.
-* Install the Javascript dependencies: `npm install`
+### Requirements:
+* Ruby (the version specified in `.ruby-version`) with `bundler` installed
+* Node `12` with `npm` installed
+* Docker (to run the FHIR validator wrapper)
+
+### Setup
+* `bundle install`
+* `npm install`
 
 ### Running the app:
 * Run the Typescript compilation engine: `npm start`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 This app is a stand-alone [FHIR](http://fhir.hl7.org/) resource validator. Using this app, you can validate a FHIR resource against an optional FHIR Profile.
 
+## Running the FHIR Validator App in development
+### Prerequisites:
+* Install the required version of Ruby: `rvm install` in the `fhir-validator-app` folder
+* Tell RVM to use that version of Ruby: `rvm use`
+  * Note: these two commands make use of the `.ruby-version` file, which specifies the version of Ruby being used by the app. That's why there's no need to specify a Ruby version to either of these commands.
+* Install Bundler: `gem install bundler`
+* Install the Ruby dependencies: `bundle install`
+* Install Node, using your method of choice
+  * I use [Node Version Manager](https://github.com/nvm-sh/nvm), but you can also install Node via homebrew with `brew install node@12` if you're on a Mac.
+* Install the Javascript dependencies: `npm install`
+
+### Running the app:
+* Run the Typescript compilation engine: `npm start`
+  * Note: this will auto-recompile whenever you save a change to one of the Typescript files, and will trigger a page refresh if you have the app open in development
+* Run the Ruby server: `bundle exec rackup`
+* Run the validator wrapper: `docker run -p 8080:4567 infernocommunity/fhir-validator-wrapper:latest`
+* Navigate to the app in your browser of choice at http://localhost:4567
+
 ## Running the FHIR Validator App in Docker
 * Build the image, using `docker build . -t fhir_validator_app`
 * Run the container, using `docker run -p 8080:4567 -e external_validator_url=<URL to external validator> fhir_validator_app`

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ This app is a stand-alone [FHIR](http://fhir.hl7.org/) resource validator. Using
 * Docker (to run the FHIR validator wrapper)
 
 ### Setup
+From the root directory of `fhir-validator-app`:
 * `bundle install`
 * `npm install`
 
 ### Running the app:
+From the root directory of `fhir-validator-app`:
 * Run the Typescript compilation engine: `npm start`
   * Note: this will auto-recompile whenever you save a change to one of the Typescript files, and will trigger a page refresh if you have the app open in development
 * Run the Ruby server: `bundle exec rackup`
@@ -18,11 +20,13 @@ This app is a stand-alone [FHIR](http://fhir.hl7.org/) resource validator. Using
 * Navigate to the app in your browser of choice at http://localhost:4567
 
 ## Running the FHIR Validator App in Docker
+From the root directory of `fhir-validator-app`:
 * Build the image, using `docker build . -t fhir_validator_app`
 * Run the container, using `docker run -p 8080:4567 -e external_validator_url=<URL to external validator> fhir_validator_app`
 * Visit the site at `http://localhost:8080`
 
 ## Running the FHIR Validator App using Docker Compose
+From the root directory of `fhir-validator-app`:
 * Build the image, using `docker-compose build`
 * Run the compose file, using `docker-compose up`. This will run both the standalone validator app, as well as the [fhir-validator-wrapper](https://github.com/inferno-community/fhir-validator-wrapper) Docker container required to do exterrnal validation.
 


### PR DESCRIPTION
The README didn't have any instructions on how to run the app in a development setting, so I added some. ﻿

Note: Dev environment setup instructions (for Mac) have been moved to https://github.com/inferno-community/fhir-validator-app/wiki/Mac-Development-Setup-Instructions
