### PR TITLE
Add cache-busting string to the production builds of main.js, and update Docker to build it correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 node_modules/
 umls.zip
 .DS_Store
+tmp/*
+
+# Ignore the dist/ files, because we're going to rebuild them anyways
+public/js/dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ resources/terminology/*
 umls.zip
 .DS_Store
 node_modules/
-public/
+public/js/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN rm -rf /var/www/fhir_validator/node_modules
 ### Set up environment
 
 ENV APP_ENV=production
+ENV RACK_ENV=production
 EXPOSE 4567
 
 CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0"]

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -19,6 +19,9 @@ module FHIRValidator
     set :views, settings.root + '/app/views'
     set :public_folder, (proc { File.join(settings.root, '..', 'public') })
     set :static, true
+    if ENV['RACK_ENV'] == 'production'
+      set :static_cache_control, [:public, max_age: 31_536_000] # cache static files for 1 year
+    end
 
     l = ::Logger.new(STDOUT, level: 'info', progname: 'Inferno')
     l.formatter = proc do |severity, _datetime, progname, msg|

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -42,11 +42,12 @@
       <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
       <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
       <script src="http://localhost:35729/livereload.js"></script>
+      <script src="<%= base_path %>/static/js/dist/main.js"></script>
     <% else %>
       <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
       <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+      <script src="<%= base_path %>/static/js/dist/<%= Dir.glob('public/js/dist/main.*.js').first.split('/').last %>"></script>
     <% end %>
 
-    <script src="<%= base_path%>/static/js/dist/main.js"></script>
   </body>
 </html>

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -2,7 +2,6 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
-
 module.exports = merge(common, {
   mode: "production",
 
@@ -10,12 +9,16 @@ module.exports = merge(common, {
   devtool: "source-map",
 
   plugins: [
-    new CleanWebpackPlugin()
+    new CleanWebpackPlugin(),
   ],
 
   optimization: {
     removeAvailableModules: true,
     removeEmptyChunks: true,
     usedExports: true
+  },
+
+  output: {
+    filename: '[name].[contenthash].js'
   }
 });


### PR DESCRIPTION
This PR adds a 'cache busting' string to the main.js creation in production. This will allow browsers to cache the `main.*.js` file for a long time, and avoid having to re-download it each time you go to the validator page, while still allowing it to change quickly when we update the Javascript

NOTE: I did not add a cache-busting element to `app.js`, because I think that's going to be phased out as we move towards React.
