### PR TITLE
Rename the resource file param field name in get_resource

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -108,7 +108,7 @@ module FHIRValidator
     end
 
     def get_resource(params)
-      resource_file = params.dig(:resource, :tempfile)
+      resource_file = params.dig(:resource_file, :tempfile)
       resource_blob = params[:resource_field]
       if resource_file
         File.read(resource_file)


### PR DESCRIPTION
Fix the parsing of resources passed via file upload in Sinatra-land. 
