### PR TITLE
Fix handling of response from /igs

### DIFF
--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -33,7 +33,7 @@ export function ProfileForm(): ReactElement {
     let aborted = false;
     if (ig && !options) {
       loadIg(ig).then(
-        (urls) => !aborted && setProfiles((profiles) => ({ ...profiles, [ig]: urls }))
+        ({ profiles: urls }) => !aborted && setProfiles((profiles) => ({ ...profiles, [ig]: urls }))
       );
     }
     return (): void => void (aborted = true);

--- a/src/models/HL7Validator.tsx
+++ b/src/models/HL7Validator.tsx
@@ -93,9 +93,11 @@ export const addProfile = async (profileBlob: string): Promise<string> => {
 export const getIgs = (): Promise<Record<string, string>> =>
   validatorFetch('GET', 'igs').then(parseJson);
 
+export type LoadIgResponse = { id: string; version: string; profiles: string[] };
+
 // This function takes a package ID of an IG from packages.fhir.org and loads
 // the IG into the external validator
-export const loadIg = (id: string): Promise<string[]> =>
+export const loadIg = (id: string): Promise<LoadIgResponse> =>
   validatorFetch('PUT', `igs/${id}`).then(parseJson);
 
 // This function retrieves a mapping from package ID of an IG to a list of


### PR DESCRIPTION
The `PUT` and `POST /igs` routes introduced in [fhir-validator-wrapper#16](https://github.com/inferno-community/fhir-validator-wrapper/pull/16) were recently changed to include more information than just the profile URLs of the IG. This PR fixes the validator app to accommodate these changes.