### PR TITLE
Fix Safari crash when reading files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,6 +2235,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "blob-polyfill": {
+      "version": "4.0.20200601",
+      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-4.0.20200601.tgz",
+      "integrity": "sha512-1jB6WOIp6IDxNyng5+9A8g/f0uiphib2ELCN+XAnlssinsW8s1k4VYG9b1TxIUd3pdm9RJSLQuBh6iohYmD4hA=="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
+    "blob-polyfill": "^4.0.20200601",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module 'blob-polyfill';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './components/App';
+import './polyfills';
 
 ReactDOM.render(
   <StrictMode>

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,5 @@
+import { Blob } from 'blob-polyfill';
+
+File.prototype.text = Blob.prototype.text;
+File.prototype.stream = Blob.prototype.stream;
+File.prototype.arrayBuffer = Blob.prototype.arrayBuffer;


### PR DESCRIPTION
This PR fixes an issue that caused Safari to crash when trying to read files using `File.text()` and `File.arrayBuffer()`. To fix this, a polyfill was added for the corresponding methods `Blob.text()` and `Blob.arrayBuffer()` that `File` inherits.