### PR TITLE
FI-1285  -- Add IG Version to Dropdown and API 

### DIFF
--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -22,12 +22,31 @@ export function ProfileForm(): ReactElement {
 
   // 1. GET /igs when component first mounts
   // 2. Default to hl7.fhir.r4.core if implementationGuide was not set on mount
+  /* 
+    If the igs state is not set, getIgs
+    If that doesn't cause an abort, then use the IGs setter and reorder igs alphabetically
+    If that doesn't cause an abort, but no Igs are actually returned/given to settr, then
+    set a selectoption of type <string, string> and pass that as value to dispatch, which does .... 
+
+  */ 
   useEffect(() => {
     let aborted = false;
     if (!igs) {
       getIgs().then((igs) => {
+        /* Okay, so right now the Igs keys are just the title, but the value has the version 
+          appended to the end of the URL in like a  /4.0.0 form. 
+          Now, check what format the keys needs to be sent the validator in i.e. what needs
+          to be pulled off the URL and then how should it be appended to the key. */
         if (!aborted) {
-          setIgs(Object.keys(igs).sort());
+          let igs_keys = Object.keys(igs)
+
+          igs_keys.forEach((id, index, igs_keys) => {
+            let version = igs[id].match(/\d+\.\d+\.\d+/g);
+            igs_keys[index] = (version ? (id + '#' + version) : id);
+          });
+
+          setIgs(igs_keys)
+
           if (!ig) {
             const value = new SelectOption('hl7.fhir.r4.core', 'hl7.fhir.r4.core');
             dispatch({ name: 'implementationGuide', value });

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -22,21 +22,10 @@ export function ProfileForm(): ReactElement {
 
   // 1. GET /igs when component first mounts
   // 2. Default to hl7.fhir.r4.core if implementationGuide was not set on mount
-  /* 
-    If the igs state is not set, getIgs
-    If that doesn't cause an abort, then use the IGs setter and reorder igs alphabetically
-    If that doesn't cause an abort, but no Igs are actually returned/given to settr, then
-    set a selectoption of type <string, string> and pass that as value to dispatch, which does .... 
-
-  */ 
   useEffect(() => {
     let aborted = false;
     if (!igs) {
       getIgs().then((igs) => {
-        /* Okay, so right now the Igs keys are just the title, but the value has the version 
-          appended to the end of the URL in like a  /4.0.0 form. 
-          Now, check what format the keys needs to be sent the validator in i.e. what needs
-          to be pulled off the URL and then how should it be appended to the key. */
         if (!aborted) {
           let igs_keys = Object.keys(igs)
 
@@ -45,7 +34,7 @@ export function ProfileForm(): ReactElement {
             igs_keys[index] = (version ? (id + '#' + version) : id);
           });
 
-          setIgs(igs_keys)
+          setIgs(igs_keys.sort())
 
           if (!ig) {
             const value = new SelectOption('hl7.fhir.r4.core', 'hl7.fhir.r4.core');

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -27,14 +27,14 @@ export function ProfileForm(): ReactElement {
     if (!igs) {
       getIgs().then((igs) => {
         if (!aborted) {
-          let igs_keys = Object.keys(igs)
+          const igsKeys = Object.keys(igs);
 
-          igs_keys.forEach((id, index, igs_keys) => {
-            let version = igs[id].match(/\d+\.\d+\.\d+/g);
-            igs_keys[index] = (version ? (id + '#' + version) : id);
+          igsKeys.forEach((id, index, igsKeys) => {
+            const version = igs[id].match(/\d+\.\d+\.\d+/g);
+            igsKeys[index] = version ? id + '#' + version : id;
           });
 
-          setIgs(igs_keys.sort())
+          setIgs(igsKeys.sort());
 
           if (!ig) {
             const value = new SelectOption('hl7.fhir.r4.core', 'hl7.fhir.r4.core');


### PR DESCRIPTION
Dropdown options menu now displays the IG version tacked onto the label. To view this change, navigate to 'Advanced Options' and then the 'Pick an Implementation Guide to validate against' dropdown. Used a regex that ought to catch anything in the canonical URL - assuming that any multi-version IG will have version info in its URL. Because of the structure of the FHIR-validator-app, these labels themselves are sent to the wrapper, so no fixes re: the API side. I noted during testing that there are some pretty gaping issues with the wrapper that need to be addressed, including how the wrapper doesn't deal with an unloadable IG (see ticket FI-933) and why unloadable IGs are listed as options in the first place.
<img width="1784" alt="Screen Shot 2021-09-21 at 8 30 36 AM" src="https://user-images.githubusercontent.com/37051655/134171461-6a859e6a-ddbd-4006-b670-a324c5ef0a43.png">
